### PR TITLE
Fix issue when a player join

### DIFF
--- a/src/main/java/com/bobcat00/tablistping/TabListPing.java
+++ b/src/main/java/com/bobcat00/tablistping/TabListPing.java
@@ -106,7 +106,7 @@ public class TabListPing extends JavaPlugin implements Listener
             @Override
             public Object onPacketOutAsync(Player receiver, Channel channel, Object packet)
             {
-                if (OUT_KEEP_ALIVE_PACKET.isInstance(packet))
+                if (OUT_KEEP_ALIVE_PACKET.isInstance(packet) && receiver != null)
                 {
                     listeners.processServerToClient(receiver);
                 }
@@ -117,7 +117,7 @@ public class TabListPing extends JavaPlugin implements Listener
             @Override
             public Object onPacketInAsync(Player sender, Channel channel, Object packet)
             {
-                if (IN_KEEP_ALIVE_PACKET.isInstance(packet))
+                if (IN_KEEP_ALIVE_PACKET.isInstance(packet) && sender != null)
                 {
                     listeners.processClientToServer(sender);
                 }


### PR DESCRIPTION
A friend on his server has this issue and doing this fixed it
I guess the issue is that some keepalive packets are sent before the player is injected by the PlayerJoinEvent of TinyProtocol

Close #1 